### PR TITLE
Add script to run gateway tests and configure integration sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.smartchat</groupId>
-	<artifactId>gateway</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>api-gateway</name>
-	<description>Gateway routing for smart chat app</description>
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.smartchat</groupId>
+        <artifactId>gateway</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <name>api-gateway</name>
+        <description>Gateway routing for smart chat app</description>
 	<url/>
 	<licenses>
 		<license/>
@@ -26,15 +20,44 @@
 		<tag/>
 		<url/>
 	</scm>
-	<properties>
-		<java.version>21</java.version>
-		<spring-cloud.version>2025.0.0</spring-cloud.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
-		</dependency>
+        <properties>
+                <java.version>21</java.version>
+                <spring-cloud.version>2025.0.0</spring-cloud.version>
+                <spring-boot.version>3.5.4</spring-boot.version>
+                <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+                <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        </properties>
+        <repositories>
+                <repository>
+                        <id>maven-central</id>
+                        <name>Maven Central Mirror</name>
+                        <url>https://repo1.maven.org/maven2/</url>
+                        <releases>
+                                <enabled>true</enabled>
+                        </releases>
+                        <snapshots>
+                                <enabled>false</enabled>
+                        </snapshots>
+                </repository>
+        </repositories>
+        <pluginRepositories>
+                <pluginRepository>
+                        <id>maven-central-plugins</id>
+                        <name>Maven Central Plugins Mirror</name>
+                        <url>https://repo1.maven.org/maven2/</url>
+                        <releases>
+                                <enabled>true</enabled>
+                        </releases>
+                        <snapshots>
+                                <enabled>false</enabled>
+                        </snapshots>
+                </pluginRepository>
+        </pluginRepositories>
+        <dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
@@ -156,13 +179,20 @@
             <type>pom</type>
         </dependency>
 	</dependencies>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
+        <dependencyManagement>
+                <dependencies>
+                        <dependency>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-dependencies</artifactId>
+                                <version>${spring-boot.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                        </dependency>
+                        <dependency>
+                                <groupId>org.springframework.cloud</groupId>
+                                <artifactId>spring-cloud-dependencies</artifactId>
+                                <version>${spring-cloud.version}</version>
+                                <type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<dependency>
@@ -176,15 +206,49 @@
 	</dependencyManagement>
 
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
+                <plugins>
+                        <plugin>
+                                <groupId>org.codehaus.mojo</groupId>
+                                <artifactId>build-helper-maven-plugin</artifactId>
+                                <version>3.6.0</version>
+                                <executions>
+                                        <execution>
+                                                <id>add-integration-test-source</id>
+                                                <phase>generate-test-sources</phase>
+                                                <goals>
+                                                        <goal>add-test-source</goal>
+                                                </goals>
+                                                <configuration>
+                                                        <sources>
+                                                                <source>src/integration-test/java</source>
+                                                        </sources>
+                                                </configuration>
+                                        </execution>
+                                        <execution>
+                                                <id>add-integration-test-resources</id>
+                                                <phase>generate-test-resources</phase>
+                                                <goals>
+                                                        <goal>add-test-resource</goal>
+                                                </goals>
+                                                <configuration>
+                                                        <resources>
+                                                                <resource>
+                                                                        <directory>src/integration-test/resources</directory>
+                                                                </resource>
+                                                        </resources>
+                                                </configuration>
+                                        </execution>
+                                </executions>
+                        </plugin>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <version>${maven-compiler-plugin.version}</version>
+                                <configuration>
+                                        <annotationProcessorPaths>
+                                                <path>
+                                                        <groupId>org.projectlombok</groupId>
+                                                        <artifactId>lombok</artifactId>
 						</path>
 						<path>
 							<groupId>org.springframework.boot</groupId>
@@ -193,18 +257,24 @@
 					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
+                        <plugin>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
+                                <version>${spring-boot.version}</version>
+                                <configuration>
+                                        <excludes>
+                                                <exclude>
+                                                        <groupId>org.projectlombok</groupId>
+                                                        <artifactId>lombok</artifactId>
 						</exclude>
 					</excludes>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+                                </configuration>
+                        </plugin>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-surefire-plugin</artifactId>
+                                <version>${maven-surefire-plugin.version}</version>
+                        </plugin>
+                </plugins>
+        </build>
 </project><!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api -->

--- a/scripts/maven-settings.xml
+++ b/scripts/maven-settings.xml
@@ -1,0 +1,5 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <proxies/>
+</settings>

--- a/scripts/run-gateway-tests.sh
+++ b/scripts/run-gateway-tests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine project root based on script location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+SETTINGS_FILE="${MAVEN_SETTINGS:-$PROJECT_ROOT/scripts/maven-settings.xml}"
+MVN_ARGS=()
+
+if [[ -f "$SETTINGS_FILE" ]]; then
+  MVN_ARGS=(-s "$SETTINGS_FILE")
+fi
+
+if command -v mvn >/dev/null 2>&1; then
+  MVN_CMD=(mvn "${MVN_ARGS[@]}")
+elif [[ -x "$PROJECT_ROOT/mvnw" ]]; then
+  MVN_CMD=("$PROJECT_ROOT/mvnw" "${MVN_ARGS[@]}")
+else
+  echo "Error: Maven is not installed and Maven wrapper is unavailable." >&2
+  exit 1
+fi
+
+exec "${MVN_CMD[@]}" -B -ntp clean test "$@"


### PR DESCRIPTION
## Summary
- configure the Maven build without the Spring Boot parent, including plugin versions, repository mirrors, and BOM imports
- add build-helper plugin wiring so the existing integration tests are compiled and executed with the standard test phase
- provide a reusable `scripts/run-gateway-tests.sh` entry point and companion Maven settings file for running the gateway test suite

## Testing
- scripts/run-gateway-tests.sh *(fails: dependency downloads blocked by the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fccd0d597c832dbc37df1f44c80c86