### PR TITLE
Add Keycloak auth and user provisioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,14 @@
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
                 </dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>

--- a/src/integration-test/resources/application-test.yaml
+++ b/src/integration-test/resources/application-test.yaml
@@ -47,6 +47,12 @@ spring:
               args:
                 regexp: "^/users(?<segment>/.*)?$"
                 replacement: "/api/users${segment:-/}"
+        - id: users-service
+          uri: ${USERS_SERVICE_URI:http://127.0.0.1:8087}
+          predicates:
+            - Path=/users-service,/users-service/**
+          filters:
+            - StripPrefix=1
         - id: chat
           uri: http://127.0.0.1:8082
           predicates:
@@ -99,6 +105,14 @@ spring:
         jwt:
           issuer-uri: ${ISSUER_URI}
           jwk-set-uri: ${KEYCLOAK_JWKS}
+keycloak:
+  admin:
+    base-url: ${KEYCLOAK_BASE_URL:http://127.0.0.1:8088}
+    realm: ${KEYCLOAK_REALM:chat-local}
+    admin-realm: ${KEYCLOAK_ADMIN_REALM:master}
+    client-id: ${KEYCLOAK_ADMIN_CLIENT_ID:admin-cli}
+    username: ${KEYCLOAK_ADMIN_USERNAME:admin}
+    password: ${KEYCLOAK_ADMIN_PASSWORD:admin}
 
 logging:
   level:

--- a/src/main/java/com/smartchat/gateway/GatewayApplication.java
+++ b/src/main/java/com/smartchat/gateway/GatewayApplication.java
@@ -2,12 +2,14 @@ package com.smartchat.gateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class GatewayApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(GatewayApplication.class, args);
-	}
+        public static void main(String[] args) {
+                SpringApplication.run(GatewayApplication.class, args);
+        }
 
 }

--- a/src/main/java/com/smartchat/gateway/configuration/KeycloakAdminProperties.java
+++ b/src/main/java/com/smartchat/gateway/configuration/KeycloakAdminProperties.java
@@ -1,0 +1,21 @@
+package com.smartchat.gateway.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "keycloak.admin")
+public record KeycloakAdminProperties(
+        String baseUrl,
+        String realm,
+        String adminRealm,
+        String clientId,
+        String username,
+        String password) {
+
+    public String tokenPath() {
+        return "/realms/" + adminRealm + "/protocol/openid-connect/token";
+    }
+
+    public String usersPath() {
+        return "/admin/realms/" + realm + "/users";
+    }
+}

--- a/src/main/java/com/smartchat/gateway/configuration/SecurityConfig.java
+++ b/src/main/java/com/smartchat/gateway/configuration/SecurityConfig.java
@@ -4,11 +4,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverter;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 
 @Configuration
@@ -22,7 +22,7 @@ public class SecurityConfig {
                         .pathMatchers("/actuator/**").permitAll()
                         .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .anyExchange().authenticated())
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())))
                 .build();
     }
 
@@ -34,5 +34,11 @@ public class SecurityConfig {
         var decoder = NimbusReactiveJwtDecoder.withJwkSetUri(jwks).build();
         decoder.setJwtValidator(JwtValidators.createDefaultWithIssuer(issuer));
         return decoder;
+    }
+
+    private ReactiveJwtAuthenticationConverter jwtAuthenticationConverter() {
+        var converter = new ReactiveJwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(new KeycloakRealmRoleConverter());
+        return converter;
     }
 }

--- a/src/main/java/com/smartchat/gateway/configuration/TrustedUserIdFilter.java
+++ b/src/main/java/com/smartchat/gateway/configuration/TrustedUserIdFilter.java
@@ -1,0 +1,71 @@
+package com.smartchat.gateway.configuration;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Locale;
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class TrustedUserIdFilter implements GlobalFilter, Ordered {
+
+    static final String USER_ID_HEADER = "X-User-Id";
+    static final int USER_ID_LENGTH = 26;
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        ServerHttpRequest sanitized = exchange.getRequest().mutate()
+                .headers(headers -> headers.remove(USER_ID_HEADER))
+                .build();
+        ServerWebExchange sanitizedExchange = exchange.mutate().request(sanitized).build();
+
+        return exchange.getPrincipal()
+                .cast(Authentication.class)
+                .map(this::resolveUserId)
+                .map(userId -> sanitizedExchange.mutate()
+                        .request(sanitizedExchange.getRequest().mutate().header(USER_ID_HEADER, userId).build())
+                        .build())
+                .defaultIfEmpty(sanitizedExchange)
+                .flatMap(chain::filter);
+    }
+
+    private String resolveUserId(Authentication authentication) {
+        String raw;
+        if (authentication instanceof JwtAuthenticationToken jwtAuthenticationToken) {
+            raw = jwtAuthenticationToken.getToken().getSubject();
+        } else {
+            raw = authentication.getName();
+        }
+        return safeUserId(raw);
+    }
+
+    private String safeUserId(String subject) {
+        if (subject == null || subject.isBlank()) {
+            return "anonymous";
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(subject.toLowerCase(Locale.ROOT).getBytes(StandardCharsets.UTF_8));
+            String encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+            return encoded.substring(0, Math.min(USER_ID_LENGTH, encoded.length()));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Missing SHA-256 algorithm", e);
+        }
+    }
+}

--- a/src/main/java/com/smartchat/gateway/provisioning/CreateUserRequest.java
+++ b/src/main/java/com/smartchat/gateway/provisioning/CreateUserRequest.java
@@ -1,0 +1,12 @@
+package com.smartchat.gateway.provisioning;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateUserRequest(
+        @NotBlank String username,
+        @Email String email,
+        @NotBlank String firstName,
+        @NotBlank String lastName,
+        @NotBlank String password) {
+}

--- a/src/main/java/com/smartchat/gateway/provisioning/KeycloakUserClient.java
+++ b/src/main/java/com/smartchat/gateway/provisioning/KeycloakUserClient.java
@@ -1,0 +1,77 @@
+package com.smartchat.gateway.provisioning;
+
+import java.util.List;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.smartchat.gateway.configuration.KeycloakAdminProperties;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class KeycloakUserClient {
+
+    private final KeycloakAdminProperties properties;
+    private final WebClient webClient;
+
+    public KeycloakUserClient(KeycloakAdminProperties properties, WebClient.Builder builder) {
+        this.properties = properties;
+        this.webClient = builder.baseUrl(properties.baseUrl()).build();
+    }
+
+    public Mono<Void> createUser(CreateUserRequest request) {
+        return adminToken()
+                .flatMap(token -> webClient.post()
+                        .uri(properties.usersPath())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bodyValue(KeycloakUserRepresentation.from(request))
+                        .retrieve()
+                        .onStatus(status -> status.isError(), response -> response.createException())
+                        .bodyToMono(Void.class));
+    }
+
+    private Mono<String> adminToken() {
+        return webClient.post()
+                .uri(properties.tokenPath())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData("grant_type", "password")
+                        .with("client_id", properties.clientId())
+                        .with("username", properties.username())
+                        .with("password", properties.password()))
+                .retrieve()
+                .onStatus(status -> status.isError(), response -> response.createException())
+                .bodyToMono(TokenResponse.class)
+                .map(TokenResponse::accessToken);
+    }
+
+    private record TokenResponse(String access_token) {
+        String accessToken() {
+            return access_token;
+        }
+    }
+
+    private record KeycloakUserRepresentation(String username,
+                                              String email,
+                                              String firstName,
+                                              String lastName,
+                                              boolean enabled,
+                                              List<Credential> credentials) {
+        static KeycloakUserRepresentation from(CreateUserRequest request) {
+            return new KeycloakUserRepresentation(
+                    request.username(),
+                    request.email(),
+                    request.firstName(),
+                    request.lastName(),
+                    true,
+                    List.of(new Credential("password", request.password(), false)));
+        }
+    }
+
+    private record Credential(String type, String value, boolean temporary) {
+    }
+}

--- a/src/main/java/com/smartchat/gateway/provisioning/UserProvisioningController.java
+++ b/src/main/java/com/smartchat/gateway/provisioning/UserProvisioningController.java
@@ -1,0 +1,29 @@
+package com.smartchat.gateway.provisioning;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/users")
+public class UserProvisioningController {
+
+    private final KeycloakUserClient userClient;
+
+    public UserProvisioningController(KeycloakUserClient userClient) {
+        this.userClient = userClient;
+    }
+
+    @PostMapping("/create")
+    public Mono<ResponseEntity<Void>> create(@Valid @RequestBody CreateUserRequest request) {
+        return userClient.createUser(request)
+                .thenReturn(ResponseEntity.status(HttpStatus.CREATED).build());
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,6 +47,12 @@ spring:
               args:
                 regexp: "^/users(?<segment>/.*)?$"
                 replacement: "/api/users${segment:-/}"
+        - id: users-service
+          uri: ${USERS_SERVICE_URI:http://users-service:8087}
+          predicates:
+            - Path=/users-service,/users-service/**
+          filters:
+            - StripPrefix=1
         - id: chat
           uri: http://chat-service:8082
           predicates:
@@ -99,6 +105,14 @@ spring:
         jwt:
           issuer-uri: ${ISSUER_URI}
           jwk-set-uri: ${KEYCLOAK_JWKS}
+keycloak:
+  admin:
+    base-url: ${KEYCLOAK_BASE_URL:http://keycloak:8080}
+    realm: ${KEYCLOAK_REALM:chat-local}
+    admin-realm: ${KEYCLOAK_ADMIN_REALM:master}
+    client-id: ${KEYCLOAK_ADMIN_CLIENT_ID:admin-cli}
+    username: ${KEYCLOAK_ADMIN_USERNAME:admin}
+    password: ${KEYCLOAK_ADMIN_PASSWORD:admin}
 
 logging:
   level:

--- a/src/test/java/com/smartchat/gateway/TrustedUserIdFilterTest.java
+++ b/src/test/java/com/smartchat/gateway/TrustedUserIdFilterTest.java
@@ -1,0 +1,61 @@
+package com.smartchat.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.web.server.ServerWebExchange;
+
+import com.smartchat.gateway.configuration.TrustedUserIdFilter;
+
+import reactor.core.publisher.Mono;
+
+class TrustedUserIdFilterTest {
+
+    private final TrustedUserIdFilter filter = new TrustedUserIdFilter();
+
+    @Test
+    void removesClientProvidedHeaderAndAddsTrustedOne() {
+        ServerHttpRequest request = MockServerHttpRequest.get("/chats")
+                .header(TrustedUserIdFilter.USER_ID_HEADER, "spoofed")
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        exchange.setPrincipal(Mono.just(new TestingAuthenticationToken("sub-123", null)));
+
+        GatewayFilterChain chain = new NoopChain();
+        filter.filter(exchange, chain).block();
+
+        HttpHeaders headers = chain.captured.getHeaders();
+        assertThat(headers.getFirst(TrustedUserIdFilter.USER_ID_HEADER))
+                .isNotEqualTo("spoofed")
+                .hasSizeLessThanOrEqualTo(TrustedUserIdFilter.USER_ID_LENGTH);
+    }
+
+    @Test
+    void leavesHeaderAbsentWhenUnauthenticated() {
+        ServerHttpRequest request = MockServerHttpRequest.get("/chats")
+                .header(TrustedUserIdFilter.USER_ID_HEADER, "spoofed")
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+        GatewayFilterChain chain = new NoopChain();
+        filter.filter(exchange, chain).block();
+
+        assertThat(chain.captured.getHeaders().containsKey(TrustedUserIdFilter.USER_ID_HEADER)).isFalse();
+    }
+
+    private static final class NoopChain implements GatewayFilterChain {
+        private ServerHttpRequest captured;
+
+        @Override
+        public Mono<Void> filter(ServerWebExchange exchange) {
+            this.captured = exchange.getRequest();
+            return Mono.empty();
+        }
+    }
+}

--- a/src/test/java/com/smartchat/gateway/provisioning/KeycloakUserClientTest.java
+++ b/src/test/java/com/smartchat/gateway/provisioning/KeycloakUserClientTest.java
@@ -1,0 +1,73 @@
+package com.smartchat.gateway.provisioning;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.smartchat.gateway.configuration.KeycloakAdminProperties;
+
+import reactor.test.StepVerifier;
+
+class KeycloakUserClientTest {
+
+    private WireMockServer server;
+    private KeycloakUserClient client;
+
+    @BeforeEach
+    void setUp() {
+        server = new WireMockServer(0);
+        server.start();
+        WireMock.configureFor("localhost", server.port());
+        KeycloakAdminProperties properties = new KeycloakAdminProperties(
+                server.baseUrl(),
+                "im",
+                "master",
+                "admin-cli",
+                "admin",
+                "admin");
+        client = new KeycloakUserClient(properties, WebClient.builder());
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop();
+    }
+
+    @Test
+    void createsUserAfterFetchingAdminToken() {
+        server.stubFor(post(urlEqualTo("/realms/master/protocol/openid-connect/token"))
+                .withRequestBody(containing("grant_type=password"))
+                .withRequestBody(containing("client_id=admin-cli"))
+                .withRequestBody(containing("username=admin"))
+                .withRequestBody(containing("password=admin"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"access_token\":\"abc\"}")));
+        server.stubFor(post(urlEqualTo("/admin/realms/im/users"))
+                .withHeader("Authorization", equalTo("Bearer abc"))
+                .withRequestBody(equalToJson("""
+                        {
+                          "username": "alice",
+                          "email": "alice@example.com",
+                          "firstName": "Alice",
+                          "lastName": "User",
+                          "enabled": true,
+                          "credentials": [
+                            { "type": "password", "value": "secret", "temporary": false }
+                          ]
+                        }
+                        """))
+                .willReturn(aResponse().withStatus(201)));
+
+        CreateUserRequest request = new CreateUserRequest("alice", "alice@example.com", "Alice", "User", "secret");
+
+        StepVerifier.create(client.createUser(request)).verifyComplete();
+    }
+}


### PR DESCRIPTION
## Summary
- configure the gateway as a JWT resource server backed by Keycloak and inject a trusted X-User-Id header from the authenticated subject
- add a Keycloak admin client plus /users/create endpoint so new requests create a Keycloak user, and expose configuration/properties for the admin client and new users-service route
- cover the new behaviors with dedicated unit tests for the user-id filter and the Keycloak user client

## Testing
- `mvn test` *(fails: dependency versions missing because the spring-boot-dependencies BOM at 3.5.4 is unavailable in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dbd0f3d74832d90d7e5da53b0495f)