### PR TITLE
Ensure Keycloak provisioning follows user service creation

### DIFF
--- a/src/integration-test/resources/application-test.yaml
+++ b/src/integration-test/resources/application-test.yaml
@@ -105,6 +105,10 @@ spring:
         jwt:
           issuer-uri: ${ISSUER_URI}
           jwk-set-uri: ${KEYCLOAK_JWKS}
+users:
+  service:
+    base-url: ${USERS_SERVICE_URI:http://127.0.0.1:8087}
+    create-path: /create
 keycloak:
   admin:
     base-url: ${KEYCLOAK_BASE_URL:http://127.0.0.1:8088}

--- a/src/main/java/com/smartchat/gateway/configuration/UsersServiceProperties.java
+++ b/src/main/java/com/smartchat/gateway/configuration/UsersServiceProperties.java
@@ -1,0 +1,7 @@
+package com.smartchat.gateway.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "users.service")
+public record UsersServiceProperties(String baseUrl, String createPath) {
+}

--- a/src/main/java/com/smartchat/gateway/provisioning/UserProvisioningController.java
+++ b/src/main/java/com/smartchat/gateway/provisioning/UserProvisioningController.java
@@ -15,15 +15,18 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/users")
 public class UserProvisioningController {
 
+    private final UserServiceClient userServiceClient;
     private final KeycloakUserClient userClient;
 
-    public UserProvisioningController(KeycloakUserClient userClient) {
+    public UserProvisioningController(UserServiceClient userServiceClient, KeycloakUserClient userClient) {
+        this.userServiceClient = userServiceClient;
         this.userClient = userClient;
     }
 
     @PostMapping("/create")
     public Mono<ResponseEntity<Void>> create(@Valid @RequestBody CreateUserRequest request) {
-        return userClient.createUser(request)
+        return userServiceClient.createUser(request)
+                .then(userClient.createUser(request))
                 .thenReturn(ResponseEntity.status(HttpStatus.CREATED).build());
     }
 }

--- a/src/main/java/com/smartchat/gateway/provisioning/UserServiceClient.java
+++ b/src/main/java/com/smartchat/gateway/provisioning/UserServiceClient.java
@@ -1,0 +1,32 @@
+package com.smartchat.gateway.provisioning;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.smartchat.gateway.configuration.UsersServiceProperties;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class UserServiceClient {
+
+    private final UsersServiceProperties properties;
+    private final WebClient webClient;
+
+    public UserServiceClient(UsersServiceProperties properties, WebClient.Builder builder) {
+        this.properties = properties;
+        this.webClient = builder.baseUrl(properties.baseUrl()).build();
+    }
+
+    public Mono<Void> createUser(CreateUserRequest request) {
+        return webClient.post()
+                .uri(properties.createPath())
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, response -> response.createException())
+                .bodyToMono(Void.class);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -105,6 +105,10 @@ spring:
         jwt:
           issuer-uri: ${ISSUER_URI}
           jwk-set-uri: ${KEYCLOAK_JWKS}
+users:
+  service:
+    base-url: ${USERS_SERVICE_URI:http://users-service:8087}
+    create-path: /create
 keycloak:
   admin:
     base-url: ${KEYCLOAK_BASE_URL:http://keycloak:8080}


### PR DESCRIPTION
## Summary
- route user creation through the user service before provisioning Keycloak accounts
- add a dedicated user service client with configurable base URL and create path
- expose user service configuration alongside existing application settings

## Testing
- mvn -q test *(fails: Maven could not download dependencies due to 403 responses from maven-central)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e086e4768832db5718a2550aecd62)