### PR TITLE
Generate hashed password for Keycloak user creation

### DIFF
--- a/src/main/java/com/smartchat/gateway/configuration/SecurityConfig.java
+++ b/src/main/java/com/smartchat/gateway/configuration/SecurityConfig.java
@@ -16,15 +16,15 @@ public class SecurityConfig {
 
     @Bean
     public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
-        return http
-                .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(ex -> ex
-                        .pathMatchers("/actuator/**").permitAll()
-                        .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .pathMatchers("/users/create").permitAll()
-                        .anyExchange().authenticated())
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())))
-                .build();
+                return http
+                        .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                        .authorizeExchange(ex -> ex
+                                .pathMatchers("/actuator/**").permitAll()
+                                .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                                .pathMatchers("/user/create", "/users/create").permitAll()
+                                .anyExchange().authenticated())
+                        .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())))
+                        .build();
     }
 
     @Bean

--- a/src/main/java/com/smartchat/gateway/provisioning/CreateUserRequest.java
+++ b/src/main/java/com/smartchat/gateway/provisioning/CreateUserRequest.java
@@ -1,12 +1,11 @@
 package com.smartchat.gateway.provisioning;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record CreateUserRequest(
+        @NotBlank String userId,
         @NotBlank String username,
-        @Email String email,
-        @NotBlank String firstName,
-        @NotBlank String lastName,
-        @NotBlank String password) {
+        @NotBlank String displayName,
+        String bio,
+        String avatarUrl) {
 }

--- a/src/main/java/com/smartchat/gateway/provisioning/KeycloakUserClient.java
+++ b/src/main/java/com/smartchat/gateway/provisioning/KeycloakUserClient.java
@@ -1,6 +1,12 @@
 package com.smartchat.gateway.provisioning;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
@@ -57,23 +63,52 @@ public class KeycloakUserClient {
         }
     }
 
-    private record KeycloakUserRepresentation(String username,
-                                              String email,
+    private record KeycloakUserRepresentation(String id,
+                                              String username,
                                               String firstName,
-                                              String lastName,
                                               boolean enabled,
-                                              List<Credential> credentials) {
+                                              Map<String, List<String>> attributes,
+                                              List<CredentialRepresentation> credentials) {
         static KeycloakUserRepresentation from(CreateUserRequest request) {
             return new KeycloakUserRepresentation(
+                    request.userId(),
                     request.username(),
-                    request.email(),
-                    request.firstName(),
-                    request.lastName(),
+                    request.displayName(),
                     true,
-                    List.of(new Credential("password", request.password(), false)));
+                    attributesFrom(request),
+                    credentialsFrom(request));
+        }
+
+        private static Map<String, List<String>> attributesFrom(CreateUserRequest request) {
+            Map<String, List<String>> attributes = new LinkedHashMap<>();
+            addAttribute(attributes, "userId", request.userId());
+            addAttribute(attributes, "displayName", request.displayName());
+            addAttribute(attributes, "bio", request.bio());
+            addAttribute(attributes, "avatarUrl", request.avatarUrl());
+            return attributes;
+        }
+
+        private static void addAttribute(Map<String, List<String>> attributes, String key, String value) {
+            if (value != null && !value.isBlank()) {
+                attributes.put(key, List.of(value));
+            }
+        }
+
+        private static List<CredentialRepresentation> credentialsFrom(CreateUserRequest request) {
+            return List.of(new CredentialRepresentation("password", false, hashedPassword(request.userId())));
+        }
+
+        private static String hashedPassword(String input) {
+            try {
+                MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+                return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalStateException("Missing SHA-256 MessageDigest", e);
+            }
         }
     }
 
-    private record Credential(String type, String value, boolean temporary) {
+    private record CredentialRepresentation(String type, boolean temporary, String value) {
     }
 }

--- a/src/test/java/com/smartchat/gateway/provisioning/KeycloakUserClientTest.java
+++ b/src/test/java/com/smartchat/gateway/provisioning/KeycloakUserClientTest.java
@@ -56,19 +56,33 @@ class KeycloakUserClientTest {
                 .withHeader("Authorization", equalTo("Bearer abc"))
                 .withRequestBody(equalToJson("""
                         {
-                          "username": "alice",
-                          "email": "alice@example.com",
-                          "firstName": "Alice",
-                          "lastName": "User",
+                          "id": "abc-1200709",
+                          "username": "user_abc124",
+                          "firstName": "frank3",
                           "enabled": true,
+                          "attributes": {
+                            "userId": ["abc-1200709"],
+                            "displayName": ["frank3"],
+                            "bio": ["test-test"],
+                            "avatarUrl": ["https://example.com/avatar.png"]
+                          },
                           "credentials": [
-                            { "type": "password", "value": "secret", "temporary": false }
+                            {
+                              "type": "password",
+                              "temporary": false,
+                              "value": "jlUCWIGMrnSavzpqpC600tIGxuiQBRNiKMl4lt50MRM"
+                            }
                           ]
                         }
                         """))
                 .willReturn(aResponse().withStatus(201)));
 
-        CreateUserRequest request = new CreateUserRequest("alice", "alice@example.com", "Alice", "User", "secret");
+        CreateUserRequest request = new CreateUserRequest(
+                "abc-1200709",
+                "user_abc124",
+                "frank3",
+                "test-test",
+                "https://example.com/avatar.png");
 
         StepVerifier.create(client.createUser(request)).verifyComplete();
     }*/

--- a/src/test/java/com/smartchat/gateway/provisioning/UserProvisioningControllerTest.java
+++ b/src/test/java/com/smartchat/gateway/provisioning/UserProvisioningControllerTest.java
@@ -1,0 +1,58 @@
+package com.smartchat.gateway.provisioning;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.smartchat.gateway.configuration.SecurityConfig;
+
+import reactor.core.publisher.Mono;
+
+@WebFluxTest(controllers = UserProvisioningController.class)
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = {
+        "spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost/.well-known/jwks.json",
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost/issuer"
+})
+class UserProvisioningControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    private UserServiceClient userServiceClient;
+
+    @MockBean
+    private KeycloakUserClient keycloakUserClient;
+
+    @Test
+    void allowsUserCreationWithoutAuthenticationAndCallsClients() {
+        CreateUserRequest request = new CreateUserRequest(
+                "abc-1200709",
+                "user_abc124",
+                "frank3",
+                "test-test",
+                "https://example.com/avatar.png");
+
+        when(userServiceClient.createUser(request)).thenReturn(Mono.empty());
+        when(keycloakUserClient.createUser(request)).thenReturn(Mono.empty());
+
+        webTestClient.post()
+                .uri("/user/create")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .exchange()
+                .expectStatus().isCreated();
+
+        verify(userServiceClient).createUser(request);
+        verify(keycloakUserClient).createUser(request);
+    }
+}


### PR DESCRIPTION
## Summary
- include Keycloak credential provisioning with a generated SHA-256-based password derived from the user id
- retain user metadata attributes while adding the required password credential payload in tests

## Testing
- `mvn test` *(fails: Maven Central returns 403 when downloading dependencies in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed820342c832db2ea3e5f162e38fd)